### PR TITLE
chore: upgrade to Go 1.25 and modernize CI for v1.2.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,9 +4,11 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45.2
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -7,12 +7,12 @@ jobs:
         go-version: [1.25.x, 1.26.x]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v6
       - name: Test
         run: go test ./...
       - name: Test (race detector)
@@ -23,12 +23,12 @@ jobs:
         go-version: [1.25.x, 1.26.x]
     runs-on: macos-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v6
       - name: Test
         # Skips ./signal (Linux-only os/signal semantics) and ./system
         # (reads /proc/{loadavg,uptime}). Everything else, including
@@ -40,12 +40,12 @@ jobs:
         go-version: [1.25.x, 1.26.x]
     runs-on: windows-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v6
       - name: Test
         # Skips ./signal (Linux-only os/signal semantics) and ./system
         # (reads /proc/{loadavg,uptime}). Everything else, including

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -4,42 +4,50 @@ jobs:
   linux:
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.25.x, 1.26.x]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Test
         run: go test ./...
+      - name: Test (race detector)
+        run: go test -race ./bus ./websocket ./signal
   macos:
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.25.x, 1.26.x]
     runs-on: macos-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Test
-        run: go test ./bus ./config ./server  # run everything but ./signal on macos
+        # Skips ./signal (Linux-only os/signal semantics) and ./system
+        # (reads /proc/{loadavg,uptime}). Everything else, including
+        # ./websocket, runs cross-OS.
+        run: go test ./bus ./config ./server ./websocket
   windows:
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.25.x, 1.26.x]
     runs-on: windows-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Test
-        run: go test ./bus ./config ./server  # run everything but ./signal on windows
+        # Skips ./signal (Linux-only os/signal semantics) and ./system
+        # (reads /proc/{loadavg,uptime}). Everything else, including
+        # ./websocket, runs cross-OS.
+        run: go test ./bus ./config ./server ./websocket

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+version: "2"
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - ineffassign
+    - unused

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 # gopher-tools
-[![Build Status](https://travis-ci.org/jjxxs/gopher-tools.svg?branch=develop)](https://travis-ci.org/jjxxs/gopher-tools)
+[![Test](https://github.com/jjxxs/gopher-tools/actions/workflows/gotest.yml/badge.svg?branch=master)](https://github.com/jjxxs/gopher-tools/actions/workflows/gotest.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/jjxxs/gopher-tools)](https://goreportcard.com/report/github.com/jjxxs/gopher-tools)
 [![Release](https://img.shields.io/github/v/release/jjxxs/gopher-tools.svg)](https://github.com/jjxxs/gopher-tools/releases/latest)
 [![License](https://img.shields.io/github/license/jjxxs/gopher-tools)](/LICENSE)

--- a/bus/worker_bus.go
+++ b/bus/worker_bus.go
@@ -76,8 +76,14 @@ func (b *workerBusImpl[E]) Publish(msg E) {
 	b.q <- msg
 }
 
+// PublishTimeout publishes a message on the Bus, waiting up to timeout for
+// queue space. A non-positive timeout returns false immediately without
+// attempting a send.
 func (b *workerBusImpl[E]) PublishTimeout(msg E, timeout time.Duration) bool {
-	t := time.NewTicker(timeout)
+	if timeout <= 0 {
+		return false
+	}
+	t := time.NewTimer(timeout)
 	defer t.Stop()
 	select {
 	case b.q <- msg:

--- a/bus/worker_bus_test.go
+++ b/bus/worker_bus_test.go
@@ -100,6 +100,60 @@ func TestMultiWorkerBusReceiverShouldNotReceivePublishMessageAfterUnsubscribe(t 
 }
 
 /**
+ * PublishTimeout edge cases (regression coverage for the Ticker→Timer fix).
+ */
+func TestPublishTimeoutSucceedsWhenSpaceAvailable(t *testing.T) {
+	b := NewWorkerBus[int](10)
+	if !b.PublishTimeout(42, 100*time.Millisecond) {
+		t.Fatal("expected PublishTimeout to return true when queue has space")
+	}
+}
+
+func TestPublishTimeoutReturnsFalseWhenQueueFull(t *testing.T) {
+	b := NewWorkerBus[int](1)
+	block := make(chan struct{})
+	defer close(block)
+	b.Subscribe(func(int) { <-block })
+
+	// Pump until the queue saturates. With the subscriber blocked, the
+	// 1-deep input queue and 1-deep sub queue will fill within a few sends.
+	saturated := false
+	for i := 0; i < 100; i++ {
+		if !b.PublishTimeout(i, 10*time.Millisecond) {
+			saturated = true
+			break
+		}
+	}
+	if !saturated {
+		t.Fatal("PublishTimeout never returned false despite blocked subscriber")
+	}
+
+	// On a saturated queue, the timeout must actually elapse.
+	start := time.Now()
+	if b.PublishTimeout(99, 50*time.Millisecond) {
+		t.Fatal("expected PublishTimeout to return false on a saturated queue")
+	}
+	if elapsed := time.Since(start); elapsed < 40*time.Millisecond {
+		t.Fatalf("PublishTimeout returned too quickly on saturated queue: %v", elapsed)
+	}
+}
+
+func TestPublishTimeoutNonPositiveReturnsFalseImmediately(t *testing.T) {
+	b := NewWorkerBus[int](10)
+	for _, timeout := range []time.Duration{0, -time.Second} {
+		start := time.Now()
+		ok := b.PublishTimeout(42, timeout)
+		elapsed := time.Since(start)
+		if ok {
+			t.Errorf("timeout=%v: expected PublishTimeout to return false", timeout)
+		}
+		if elapsed > 10*time.Millisecond {
+			t.Errorf("timeout=%v: returned too slowly (%v) — non-positive must short-circuit", timeout, elapsed)
+		}
+	}
+}
+
+/**
  * Benchmarks
  */
 func BenchmarkMultiWorkerBusPublishPrimitive__1_Subs(b *testing.B) {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
 module github.com/jjxxs/gopher-tools
 
-go 1.18
+go 1.25
 
-require (
-	github.com/gorilla/websocket v1.4.2
-	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
-)
+require github.com/gorilla/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/signal/handler_singleton_test.go
+++ b/signal/handler_singleton_test.go
@@ -2,37 +2,38 @@ package signal
 
 import (
 	"os"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
 )
 
 func TestHandle(t *testing.T) {
-	count := 0
+	var count atomic.Int32
 	Handle(func(signal os.Signal) {
-		count++
+		count.Add(1)
 	}, syscall.SIGUSR1)
 	p, _ := os.FindProcess(os.Getpid())
 	_ = p.Signal(syscall.SIGUSR1)
 	time.Sleep(100 * time.Millisecond) // signals are delivered async, wait a little
 	_ = p.Signal(syscall.SIGUSR1)
 	time.Sleep(100 * time.Millisecond) // signals are delivered async, wait a little
-	if count != 2 {
+	if count.Load() != 2 {
 		t.Fail()
 	}
 }
 
 func TestHandleOneShot(t *testing.T) {
-	count := 0
+	var count atomic.Int32
 	handlerFunc := func(sig os.Signal) {
-		count++
+		count.Add(1)
 	}
 	HandleOneShot(handlerFunc, syscall.SIGUSR1)
 	p, _ := os.FindProcess(os.Getpid())
 	_ = p.Signal(syscall.SIGUSR1)
 	_ = p.Signal(syscall.SIGUSR1)
 	time.Sleep(100 * time.Millisecond) // signals are delivered async, wait a little
-	if count != 1 {
+	if count.Load() != 1 {
 		t.Fail()
 	}
 }

--- a/signal/handler_test.go
+++ b/signal/handler_test.go
@@ -2,6 +2,7 @@ package signal
 
 import (
 	"os"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -9,47 +10,43 @@ import (
 
 func TestHandlerShouldCallCallbacks(t *testing.T) {
 	handler := NewHandler()
-	countSigUsr1 := 0
-	countSigUsr2 := 0
-	other := 0
+	var countSigUsr1, countSigUsr2, other atomic.Int32
 	handler.Register(func(signal os.Signal) {
 		switch signal {
 		case syscall.SIGUSR1:
-			countSigUsr1++
+			countSigUsr1.Add(1)
 		case syscall.SIGUSR2:
-			countSigUsr2++
+			countSigUsr2.Add(1)
 		default:
-			other++
+			other.Add(1)
 		}
 	}, syscall.SIGUSR1, syscall.SIGUSR2)
 	p, _ := os.FindProcess(os.Getpid())
 	_ = p.Signal(syscall.SIGUSR1)
 	_ = p.Signal(syscall.SIGUSR2)
 	time.Sleep(100 * time.Millisecond) // signals are delivered async, wait a little
-	if countSigUsr1 != 1 {
+	if countSigUsr1.Load() != 1 {
 		t.Fail()
 	}
-	if countSigUsr2 != 1 {
+	if countSigUsr2.Load() != 1 {
 		t.Fail()
 	}
-	if other != 0 {
+	if other.Load() != 0 {
 		t.Fail()
 	}
 }
 
 func TestHandlerShouldNotCallAfterUnregister(t *testing.T) {
 	handler := NewHandler()
-	countSigUsr1 := 0
-	countSigUsr2 := 0
-	other := 0
+	var countSigUsr1, countSigUsr2, other atomic.Int32
 	cb := func(signal os.Signal) {
 		switch signal {
 		case syscall.SIGUSR1:
-			countSigUsr1++
+			countSigUsr1.Add(1)
 		case syscall.SIGUSR2:
-			countSigUsr2++
+			countSigUsr2.Add(1)
 		default:
-			other++
+			other.Add(1)
 		}
 	}
 	handler.Register(cb, syscall.SIGUSR1, syscall.SIGUSR2)
@@ -61,22 +58,22 @@ func TestHandlerShouldNotCallAfterUnregister(t *testing.T) {
 	_ = p.Signal(syscall.SIGUSR1) // these shouldn't be received
 	_ = p.Signal(syscall.SIGUSR2)
 	time.Sleep(100 * time.Millisecond) // signals are delivered async, wait a little
-	if countSigUsr1 != 1 {
+	if countSigUsr1.Load() != 1 {
 		t.Fail()
 	}
-	if countSigUsr2 != 1 {
+	if countSigUsr2.Load() != 1 {
 		t.Fail()
 	}
-	if other != 0 {
+	if other.Load() != 0 {
 		t.Fail()
 	}
 }
 
 func TestHandlerShouldNotCallAfterExit(t *testing.T) {
 	handler := NewHandler()
-	count := 0
+	var count atomic.Int32
 	handler.Register(func(signal os.Signal) {
-		count++
+		count.Add(1)
 	}, syscall.SIGUSR1)
 	p, _ := os.FindProcess(os.Getpid())
 	_ = p.Signal(syscall.SIGUSR1)      // should be received
@@ -84,7 +81,7 @@ func TestHandlerShouldNotCallAfterExit(t *testing.T) {
 	handler.Exit()
 	_ = p.Signal(syscall.SIGUSR1)      // should not be received
 	time.Sleep(100 * time.Millisecond) // signals are delivered async, wait a little
-	if count != 1 {
+	if count.Load() != 1 {
 		t.Fail()
 	}
 }

--- a/signal/shutdown_context.go
+++ b/signal/shutdown_context.go
@@ -19,8 +19,8 @@ type key string
 
 const shutdownGroupKey key = "github.com/jjxxs/gopher-tools/signal/shutdownGroupKey"
 
-var invalidWaitGroup = errors.New("context has invalid wait-group")
-var hasNoWaitGroup = errors.New("context has no wait-group")
+var errInvalidWaitGroup = errors.New("context has invalid wait-group")
+var errHasNoWaitGroup = errors.New("context has no wait-group")
 
 // GetShutdownContext decorates a given context and returns it together
 // with a cancel-function. RegisterOnShutdownCallback can now be used
@@ -41,10 +41,10 @@ func WaitForShutdownContext(ctx context.Context) error {
 		if shutdownGroup, ok := val.(*sync.WaitGroup); ok {
 			shutdownGroup.Wait()
 		} else {
-			return invalidWaitGroup
+			return errInvalidWaitGroup
 		}
 	} else {
-		return hasNoWaitGroup
+		return errHasNoWaitGroup
 	}
 	return nil
 }
@@ -61,10 +61,10 @@ func RegisterOnShutdownCallback(ctx context.Context, callback func()) error {
 				shutdownGroup.Done()
 			}()
 		} else {
-			return invalidWaitGroup
+			return errInvalidWaitGroup
 		}
 	} else {
-		return hasNoWaitGroup
+		return errHasNoWaitGroup
 	}
 	return nil
 }

--- a/system/system.go
+++ b/system/system.go
@@ -2,7 +2,7 @@ package system
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -48,7 +48,7 @@ type CpuLoadAverages struct {
 // CpuLoad retrieves the average cpu load over past 1, 5, 15 minutes via /proc/loadavg.
 func CpuLoad() (load CpuLoadAverages, err error) {
 	var bs []byte
-	if bs, err = ioutil.ReadFile("/proc/loadavg"); err == nil {
+	if bs, err = os.ReadFile("/proc/loadavg"); err == nil {
 		var j int
 		if j, err = fmt.Sscanf(string(bs), "%f %f %f", &load.Avg1, &load.Avg5, &load.Avg15); err != nil || j != 3 {
 			err = fmt.Errorf("failed to parse output")
@@ -60,7 +60,7 @@ func CpuLoad() (load CpuLoadAverages, err error) {
 // Uptime retrieves the system uptime in seconds via /proc/uptime.
 func Uptime() (uptime int64, err error) {
 	var bs []byte
-	if bs, err = ioutil.ReadFile("/proc/uptime"); err == nil {
+	if bs, err = os.ReadFile("/proc/uptime"); err == nil {
 		if uptime, err = strconv.ParseInt(strings.Split(string(bs), ".")[0], 10, 64); err != nil {
 			err = fmt.Errorf("failed to parse output")
 		}
@@ -71,7 +71,7 @@ func Uptime() (uptime int64, err error) {
 // UptimeMs retrieves the system uptime in milliseconds via /proc/uptime.
 func UptimeMs() (uptimeMs int64, err error) {
 	var bs []byte
-	if bs, err = ioutil.ReadFile("/proc/uptime"); err == nil {
+	if bs, err = os.ReadFile("/proc/uptime"); err == nil {
 		var f64 float64
 		if f64, err = strconv.ParseFloat(strings.Split(string(bs), " ")[0], 64); err == nil {
 			uptimeMs = int64(f64 * 1000)

--- a/websocket/connection.go
+++ b/websocket/connection.go
@@ -58,7 +58,7 @@ func (c *connectionImpl) Conn() *websocket.Conn {
 
 func (c *connectionImpl) Close() {
 	c.shutdownOnce.Do(func() {
-		c.stop <- struct{}{}
+		close(c.stop)
 	})
 }
 

--- a/websocket/connection_test.go
+++ b/websocket/connection_test.go
@@ -58,6 +58,49 @@ func TestConnectionClientCloses(t *testing.T) {
 	waitForCloseEventOrFail(t, clientCloseStream, 100*time.Millisecond, 1000, "")
 }
 
+func TestConnectionCloseIsIdempotent(t *testing.T) {
+	closeStream, closeHandler := getCloseEventStream()
+	svrSideConns := serverAcceptConnectAt(t, t.Name(), nil, closeHandler, nil)
+	clientConn := clientConnectToServerAt(t, t.Name(), nil, nil, nil)
+	_ = waitForConnectionOrFail(t, svrSideConns, 100*time.Millisecond)
+
+	// Two Close() calls in a row must not panic — sync.Once + close(c.stop)
+	// is the guarantee under test.
+	clientConn.Close()
+	clientConn.Close()
+
+	// Server should observe exactly one close event.
+	waitForCloseEventOrFail(t, closeStream, 100*time.Millisecond, 1000, "")
+	select {
+	case <-closeStream:
+		t.Fatal("server observed a second close event from an idempotent Close()")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestConnectionConcurrentClose(t *testing.T) {
+	svrSideConns := serverAcceptConnectAt(t, t.Name(), nil, nil, nil)
+	clientConn := clientConnectToServerAt(t, t.Name(), nil, nil, nil)
+	_ = waitForConnectionOrFail(t, svrSideConns, 100*time.Millisecond)
+
+	// N goroutines racing on Close() must neither panic nor deadlock.
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			clientConn.Close()
+		}()
+	}
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("concurrent Close() calls deadlocked")
+	}
+}
+
 func TestConcurrentConnections(t *testing.T) {
 	const concurrentConnections = 100
 	const messagesPerConnection = 10


### PR DESCRIPTION
## Summary

- Bump Go floor `1.18` → `1.25` and `gorilla/websocket` `v1.4.2` → `v1.5.3`; drop the unused `x/sys` indirect dep.
- Modernize CI: `actions/checkout@v6`, `actions/setup-go@v6` (cache now hashes `go.sum`), `golangci-lint-action@v9` with `golangci-lint v2.12.2` exact-pinned and a new v2-schema `.golangci.yml`. Go matrix becomes `[1.25.x, 1.26.x]` across Linux/macOS/Windows; `./websocket` joins the cross-OS lane; new Linux-only `-race` step.
- Code: `io/ioutil.ReadFile` → `os.ReadFile`; `bus.PublishTimeout` switches `Ticker` → `Timer` and short-circuits non-positive timeouts; `websocket.Connection.Close` uses the canonical `close(c.stop)` idiom. Regression tests added; pre-existing data races in `signal/*_test.go` fixed with `atomic.Int32`. Dead Travis badge replaced with the GitHub Actions badge.

`signal.Handler` API redesign (Issue 7) is intentionally deferred to a follow-up. No breaking Go API changes; the floor bump is the only consumer-facing impact.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test -race ./bus ./websocket ./signal`
- [x] `go test -bench=. ./bus` — no regressions
- [x] `golangci-lint v2.12.2 run` — 0 issues
- [x] CI matrix `[1.25.x, 1.26.x]` × `[ubuntu, macos, windows]` green
- [x] Lint workflow green
- [x] Tag `v1.2.0` after merge
